### PR TITLE
Typo in auto_install.sql - breaks installation process

### DIFF
--- a/sql/auto_install.sql
+++ b/sql/auto_install.sql
@@ -13,6 +13,6 @@ CREATE TABLE IF NOT EXISTS civicrm_zoom_registrants (
   `last_name` varchar(255),
   `email` varchar(255),
   CONSTRAINT FK_civicrm_zoom_registrants_event_id FOREIGN KEY (`event_id`) REFERENCES `civicrm_event`(`id`) ON DELETE CASCADE
-) ENGINE=InnoDB";
+) ENGINE=InnoDB;
 
 CREATE UNIQUE INDEX Idx_event_id_email ON civicrm_zoom_registrants (event_id, email);


### PR DESCRIPTION
Typo in auto_install.sql - breaks installation process as shown below.

```
CREATE TABLE IF NOT EXISTS civicrm_zoom_registrants (
  `id` int unsigned NOT NULL PRIMARY KEY UNIQUE AUTO_INCREMENT  COMMENT 'Id',
  `event_id` int unsigned NOT NULL COMMENT 'FK to Event ID',
  `first_name` varchar(255),
  `last_name` varchar(255),
  `email` varchar(255),
  CONSTRAINT FK_civicrm_zoom_registrants_event_id FOREIGN KEY (`event_id`) REFERENCES `civicrm_event`(`id`) ON DELETE CASCADE
) ENGINE=InnoDB";
```

Agileware Ref: CIVICRM-1708