### PR TITLE
filterZoomRegistrantsByTime converts registration time from UTC to local timezone causing time comparison to be wrong

### DIFF
--- a/CRM/NcnCiviZoom/Utils.php
+++ b/CRM/NcnCiviZoom/Utils.php
@@ -276,12 +276,7 @@ class CRM_NcnCiviZoom_Utils {
     }
     $recentRegistrants = [];
     foreach ($registrantsList as $registrant) {
-      $registrationTime = $registrant['create_time'];
-
-      $registrationTime = str_replace(['T','Z'], [' ',''], $registrationTime);
-      $registrationTime = date($registrationTime);
-      $now = date('Y-m-d h:i:s');
-      $seconds = strtotime($now) - strtotime($registrationTime);
+      $seconds = strtotime("now") - strtotime($registrant['create_time']);
       $mins = ($seconds/60);
       if($mins < $minsBack){
         $recentRegistrants[] = $registrant;


### PR DESCRIPTION
filterZoomRegistrantsByTime converts registration time from UTC to local timezone causing time comparison to be wrong. Zoom Event Registration date/time is a UTC timezone and must be passed directly to strtotime with the timezone (Z) which indicates UTC.

Agileware Ref: CIVICRM-1712