### PR TITLE
Fix ref to 'Participant' in CiviRules Trigger data

### DIFF
--- a/CRM/CivirulesActions/Participant/AddToZoom.php
+++ b/CRM/CivirulesActions/Participant/AddToZoom.php
@@ -134,7 +134,7 @@ class CRM_CivirulesActions_Participant_AddToZoom extends CRM_Civirules_Action{
 
 		CRM_Core_Error::debug_var('Zoom addParticipant result', $result);
 		if(!empty($result['join_url'])){
-			$participantId = $triggerData->getEntityData('participant')['participant_id'];
+			$participantId = $triggerData->getEntityData('Participant')['participant_id'];
 			CRM_NcnCiviZoom_Utils::updateZoomParticipantJoinLink($participantId, $result['join_url']);
 		}
 


### PR DESCRIPTION
The CiviRules trigger passes in participant data using the label 'Participant' not 'participant'