### PR TITLE
#20138 - Avoid pushing imported participants back to zoom

### DIFF
--- a/CRM/CivirulesActions/Participant/AddToZoom.php
+++ b/CRM/CivirulesActions/Participant/AddToZoom.php
@@ -147,6 +147,13 @@ class CRM_CivirulesActions_Participant_AddToZoom extends CRM_Civirules_Action{
 	 */
 	private function addParticipant($participant, $entityID, $triggerData, $entity) {
 		$event = $triggerData->getEntityData('Event');
+
+		// GK Veda#20138 : Check if participant record was imported from zoom and avoid pushing it back to zoom again
+		$importedFromZoom = CRM_NcnCiviZoom_Utils::isImportedFromZoom($participant, $event['id']);
+		if ($importedFromZoom) {
+			return;
+		}
+
 		$accountId = CRM_NcnCiviZoom_Utils::getZoomAccountIdByEventId($event['id']);
 		$settings = CRM_NcnCiviZoom_Utils::getZoomSettings();
 		if($entity == 'Webinar'){

--- a/CRM/NcnCiviZoom/Utils.php
+++ b/CRM/NcnCiviZoom/Utils.php
@@ -1475,4 +1475,29 @@ class CRM_NcnCiviZoom_Utils {
       }
     }
   }
+
+  /*
+   * Function to check if a participant record is imported from zoom
+   */
+  public static function isImportedFromZoom($participant, $eventId) {
+    $importedFromZoom = FALSE;
+    if(empty($participant['email']) || !isset($eventId) ){
+      CRM_Core_Error::debug_log_message('Required Params Missing or not in proper format in  '.__CLASS__.'::'.__FUNCTION__);
+      CRM_Core_Error::debug_var('participant', $participant);
+      CRM_Core_Error::debug_var('eventId', $eventId);
+      return $importedFromZoom;
+    }
+
+    $tableName = CRM_NcnCiviZoom_Constants::ZOOM_REGISTRANTS_TABLE_NAME;
+    $getZoomRegistrantQuery = "SELECT * FROM ".$tableName." WHERE event_id = %1 AND email = %2";
+    $qParams = array(
+      1 => array($eventId, 'Integer'),
+      2 => array($participant['email'], 'String'),
+    );
+    $dao = CRM_Core_DAO::executeQuery($getZoomRegistrantQuery, $qParams);
+    while ($dao->fetch()) {
+      $importedFromZoom = TRUE;
+    }
+    return $importedFromZoom;
+  }
 }


### PR DESCRIPTION
Avoid pushing participants back to zoom, if the record was originally imported from zoom